### PR TITLE
Update Azure-npm to v0.0.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ CNM_PLUGIN_ROOTFS = azure-vnet-plugin-rootfs
 
 # Azure network policy manager parameters.
 AZURE_NPM_IMAGE = containernetworking/azure-npm
-AZURE_NPM_VERSION = v0.0.3
+AZURE_NPM_VERSION = v0.0.4
 
 VERSION ?= $(shell git describe --tags --always --dirty)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates Azure-npm to v0.0.4. This version fixes an issue that prevent Azure-npm with blocking traffic from other namespaces.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
https://github.com/Azure/azure-container-networking/issues/185